### PR TITLE
ALBとRoute53とACMの作成

### DIFF
--- a/handson/main.tf
+++ b/handson/main.tf
@@ -411,3 +411,19 @@ resource "aws_lb_target_group" "example" {
 
   depends_on = [aws_lb.example]
 }
+
+resource "aws_lb_listener_rule" "example" {
+  listener_arn = aws_lb_listener.https.arn
+  priority = 100
+
+  action {
+    type = "forward"
+    target_group_arn = aws_lb_target_group.example.arn
+  }
+
+  condition {
+    field = "path-pattern"
+    values = ["/*"]
+  }
+
+}

--- a/handson/main.tf
+++ b/handson/main.tf
@@ -267,3 +267,7 @@ resource "aws_lb" "example" {
     Name = "alb_example"
   }
 }
+
+output "alb_dns_name" {
+  value = aws_lb.example.dns_name
+}

--- a/handson/main.tf
+++ b/handson/main.tf
@@ -390,4 +390,24 @@ resource "aws_lb_listener" "redirect_http_to_https" {
   }
 }
 
+resource "aws_lb_target_group" "example" {
+  name = "example"
+  target_type = "ip"
+  vpc_id = aws_vpc.example.id
+  port = 80
+  protocol = "HTTP"
+  deregistration_delay = 300
 
+  health_check {
+    path = "/"
+    healthy_threshold = 5
+    unhealthy_threshold = 2
+    timeout = 5
+    interval = 30
+    matcher = 200
+    port = "traffic-port"
+    protocol = "HTTP"
+  }
+
+  depends_on = [aws_lb.example]
+}

--- a/handson/main.tf
+++ b/handson/main.tf
@@ -271,3 +271,28 @@ resource "aws_lb" "example" {
 output "alb_dns_name" {
   value = aws_lb.example.dns_name
 }
+
+module "http_sg" {
+  source = "./security_group"
+  name = "http-sg"
+  vpc_id = aws_vpc.example.id
+  port = 80
+  cidr_blocks = ["0.0.0.0/0"]
+}
+
+module "https_sg" {
+  source = "./security_group"
+  name = "https-sg"
+  vpc_id = aws_vpc.example.id
+  port = 443
+  cidr_blocks = ["0.0.0.0/0"]
+}
+
+module "http_redirect_sg" {
+  source = "./security_group"
+  name = "http-redirect-sg"
+  vpc_id = aws_vpc.example.id
+  port = 8080
+  cidr_blocks = ["0.0.0.0/0"]
+}
+

--- a/handson/main.tf
+++ b/handson/main.tf
@@ -329,3 +329,7 @@ resource "aws_route53_record" "example" {
   }
 }
 
+output "domain_name" {
+  value = aws_route53_record.example.name
+}
+

--- a/handson/main.tf
+++ b/handson/main.tf
@@ -343,4 +343,11 @@ resource "aws_acm_certificate" "example" {
   }
 }
 
+resource "aws_route53_record" "example_certificate" {
+  name = aws_acm_certificate.example.domain_validation_options[0].resource_record_name
+  type = aws_acm_certificate.example.domain_validation_options[0].resource_record_type
+  records = [aws_acm_certificate.example.domain_validation_options[0].resource_record_value]
+  zone_id = data.aws_route53_zone.example.id
+  ttl = 60
+}
 

--- a/handson/main.tf
+++ b/handson/main.tf
@@ -296,3 +296,20 @@ module "http_redirect_sg" {
   cidr_blocks = ["0.0.0.0/0"]
 }
 
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.example.arn
+  port = "80"
+  protocol = "HTTP"
+
+  default_action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "これはhttpです"
+      status_code = "200"
+    }
+  }
+}
+
+

--- a/handson/main.tf
+++ b/handson/main.tf
@@ -312,4 +312,7 @@ resource "aws_lb_listener" "http" {
   }
 }
 
+data "aws_route53_zone" "example" {
+  name = "jun-web-free.com"
+}
 

--- a/handson/main.tf
+++ b/handson/main.tf
@@ -351,3 +351,8 @@ resource "aws_route53_record" "example_certificate" {
   ttl = 60
 }
 
+resource "aws_acm_certificate_validation" "example" {
+  certificate_arn = aws_acm_certificate.example.arn
+  validation_record_fqdns = [aws_route53_record.example_certificate.fqdn]
+}
+

--- a/handson/main.tf
+++ b/handson/main.tf
@@ -373,3 +373,21 @@ resource "aws_lb_listener" "https" {
     }
   }
 }
+
+resource "aws_lb_listener" "redirect_http_to_https" {
+  load_balancer_arn = aws_lb.example.arn
+  port = "8080"
+  protocol = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port = "443"
+      protocol = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+

--- a/handson/main.tf
+++ b/handson/main.tf
@@ -241,3 +241,29 @@ module "example_sg" {
   cidr_blocks = ["0.0.0.0/0"]
 }
 
+resource "aws_lb" "example" {
+  name = "example"
+  load_balancer_type = "application"
+  internal = false
+  idle_timeout = 60
+  enable_deletion_protection = true
+
+  subnets = [
+    aws_subnet.public_0.id,
+    aws_subnet.public_1.id,
+  ]
+
+  access_logs {
+    bucket = aws_s3_bucket.alb_log.id
+    enabled = true
+  }
+
+  security_groups = [
+    module.http_sg.security_group_id,
+    module.https_sg.security_group_id,
+    module.http_redirect_sg.security_group_id,
+  ]
+  tags = {
+    Name = "alb_example"
+  }
+}

--- a/handson/main.tf
+++ b/handson/main.tf
@@ -356,3 +356,20 @@ resource "aws_acm_certificate_validation" "example" {
   validation_record_fqdns = [aws_route53_record.example_certificate.fqdn]
 }
 
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.example.arn
+  port = "443"
+  protocol = "HTTPS"
+  certificate_arn = aws_acm_certificate.example.arn
+  ssl_policy = "ELBSecurityPolicy-2016-08"
+
+  default_action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "これはHTTPSです"
+      status_code = "200"
+    }
+  }
+}

--- a/handson/main.tf
+++ b/handson/main.tf
@@ -333,3 +333,14 @@ output "domain_name" {
   value = aws_route53_record.example.name
 }
 
+resource "aws_acm_certificate" "example" {
+  domain_name = aws_route53_record.example.name
+  subject_alternative_names = []
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+

--- a/handson/main.tf
+++ b/handson/main.tf
@@ -316,3 +316,16 @@ data "aws_route53_zone" "example" {
   name = "jun-web-free.com"
 }
 
+resource "aws_route53_record" "example" {
+  zone_id = data.aws_route53_zone.example.zone_id
+  name = data.aws_route53_zone.example.name
+
+  type = "A"
+
+  alias {
+    name = aws_lb.example.dns_name
+    zone_id = aws_lb.example.zone_id
+    evaluate_target_health = true
+  }
+}
+


### PR DESCRIPTION
# What
ALBとRoute53とACMでロードバランサーとDNS周りのHCLを作成しました。

# Why
ALBで負荷分散を行うためです
Route53でオリジナルのDNSを作成するためです
ACMでSSL証明書の作成を自動化するためです