### PR TITLE
SSMの作成

### DIFF
--- a/handson/batch_container_definitions.json
+++ b/handson/batch_container_definitions.json
@@ -11,6 +11,18 @@
         "awslogs-group": "/ecs-scheduled-tasks/example"
       }
     },
-    "command": ["/bin/date"]
+    "secrets": [
+      {
+        "name": "DB_USERNAME",
+        "valueFrom": "/db/username"
+      },
+      {
+        "name": "DB_PASSWORD",
+        "valueFrom": "/db/password"
+      }
+    ],
+    "command": ["/usr/bin/env"]
   }
 ]
+
+

--- a/handson/main.tf
+++ b/handson/main.tf
@@ -575,3 +575,12 @@ resource "aws_ssm_parameter" "db_username" {
   description = "データベースのユーザー名"
 }
 
+resource "aws_ssm_parameter" "db_password" {
+  name = "/db/password"
+  value = "uninitialized"
+  type = "SecureString"
+  description = "データベースのパスワード"
+  lifecycle {
+    ignore_changes = [value]
+  }
+}

--- a/handson/main.tf
+++ b/handson/main.tf
@@ -568,3 +568,10 @@ resource "aws_kms_alias" "example" {
   target_key_id = aws_kms_key.example.key_id
 }
 
+resource "aws_ssm_parameter" "db_username" {
+  name = "/db/username"
+  value = "root"
+  type = "String"
+  description = "データベースのユーザー名"
+}
+


### PR DESCRIPTION
# What
SSMを作成するHCLを作成しました。

# Why
秘匿情報をバージョン管理するとまずいので、AWS上に暗号で保存するためです