### PR TITLE
KinesisDataFirehoseのリソース作成

### DIFF
--- a/handson/main.tf
+++ b/handson/main.tf
@@ -1015,3 +1015,16 @@ resource "aws_ssm_document" "session_manages_run_shell" {
   }
   EOF
 }
+
+resource "aws_s3_bucket" "cloudwatch_logs" {
+  bucket = "junbucket-cloudwatch"
+
+  lifecycle_rule {
+    enabled = true
+
+    expiration {
+      days = "180"
+    }
+  }
+  force_destroy = true
+}

--- a/handson/main.tf
+++ b/handson/main.tf
@@ -1066,3 +1066,24 @@ resource "aws_kinesis_firehose_delivery_stream" "example" {
     prefix = "ecs-scheduled-tasks/example/"
   }
 }
+
+data "aws_iam_policy_document" "cloudwatch_logs" {
+  statement {
+    effect = "Allow"
+    actions = ["firehose:*"]
+    resources = ["arn:aws:firehose:ap-northeast-1:*:*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = ["iam:PassRole"]
+    resources = ["arn:aws:iam::*:role/cloudwatch-logs"]
+  }
+}
+
+module "cloudwatch_logs_role" {
+  source = "./iam_role"
+  name = "cloudwatch-logs"
+  identifier = "logs.ap-northeast-1.amazonaws.com"
+  policy = data.aws_iam_policy_document.cloudwatch_logs.json
+}

--- a/handson/main.tf
+++ b/handson/main.tf
@@ -1055,3 +1055,14 @@ module "kinesis_data_firehose_role" {
   identifier = "firehose.amazonaws.com"
   policy = data.aws_iam_policy_document.kinesis_data_firehose.json
 }
+
+resource "aws_kinesis_firehose_delivery_stream" "example" {
+  name = "example"
+  destination = "s3"
+
+  s3_configuration {
+    role_arn = module.kinesis_data_firehose_role.iam_role_arn
+    bucket_arn = aws_s3_bucket.cloudwatch_logs.arn
+    prefix = "ecs-scheduled-tasks/example/"
+  }
+}

--- a/handson/main.tf
+++ b/handson/main.tf
@@ -1087,3 +1087,11 @@ module "cloudwatch_logs_role" {
   identifier = "logs.ap-northeast-1.amazonaws.com"
   policy = data.aws_iam_policy_document.cloudwatch_logs.json
 }
+
+resource "aws_cloudwatch_log_subscription_filter" "example" {
+  name = "example"
+  log_group_name = aws_cloudwatch_log_group.for_ecs_scheduled_tasks.name
+  destination_arn = aws_kinesis_firehose_delivery_stream.example.arn
+  filter_pattern = "[]"
+  role_arn = module.cloudwatch_logs_role.iam_role_arn
+}

--- a/handson/main.tf
+++ b/handson/main.tf
@@ -1028,3 +1028,30 @@ resource "aws_s3_bucket" "cloudwatch_logs" {
   }
   force_destroy = true
 }
+
+data "aws_iam_policy_document" "kinesis_data_firehose" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:PutObject",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.cloudwatch_logs.id}",
+      "arn:aws:s3:::${aws_s3_bucket.cloudwatch_logs.id}/*",
+    ]
+  }
+}
+
+module "kinesis_data_firehose_role" {
+  source = "./iam_role"
+  name = "kinesis-data-firehose"
+  identifier = "firehose.amazonaws.com"
+  policy = data.aws_iam_policy_document.kinesis_data_firehose.json
+}


### PR DESCRIPTION
# What
CloudWatchLogsのデータをS3に保存するようにしました。

# Why
CloudWatchLogsのストレージは割高だからです。